### PR TITLE
Fix dead links in eiffel-operations-extension.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: python
 python:
 - 3.5.1

--- a/eiffel-vocabulary/EiffelAlertAcknowledgedEvent.md
+++ b/eiffel-vocabulary/EiffelAlertAcknowledgedEvent.md
@@ -21,7 +21,7 @@ The EiffelAlertAcknowledgedEvent is to declare that an previously raised inciden
 ## Data Members
 ### data.acknowledgement
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The Acknowledgement response for the Alert.
 
 ### data.entity
@@ -31,7 +31,7 @@ __Description:__ The identity of the user or entity that acknowledged the alert.
 
 ## Links
 ### ALERT
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelAlertRaisedEvent](./EiffelAlertRaisedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the ALERT that has been acknowledged.
@@ -49,7 +49,7 @@ __Multiple allowed:__ No
 __Description:__ Identifies the activity of which this event constitutes a part.
 
 ### FLOW_CONTEXT
-__Required:__ No  
+__Required:__ No   
 __Legal targets:__ [EiffelFlowContextDefinedEvent](https://github.com/eiffel-community/eiffel/blob/edition-agen/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md)  
 __Multiple allowed:__ Yes  
 __Description:__ Identifies the flow context of the event: which is the continuous integration and delivery flow in which this occurred – e.g. which product, project, track or version this is applicable to.
@@ -58,25 +58,25 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -87,7 +87,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -104,7 +104,7 @@ __Required:__ No
 __Description:__ The hostname of the event sender.
 
 #### meta.source.name
-__Type:__ String  
+__Type:__ String     
 __Format:__ Free text  
 __Required:__ No  
 __Description:__ The name of the event sender.
@@ -123,19 +123,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__   
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -147,37 +147,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelAlertCeasedEvent.md
+++ b/eiffel-vocabulary/EiffelAlertCeasedEvent.md
@@ -26,7 +26,7 @@ __Description:__ The identity of the user or entity that ceased the incident.
 
 ## Links
 ### ALERT
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelAlertRaisedEvent](./EiffelAlertRaisedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the ALERT that has been resolved.
@@ -53,25 +53,25 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -82,7 +82,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -118,19 +118,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -142,37 +142,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelAlertRaisedEvent.md
+++ b/eiffel-vocabulary/EiffelAlertRaisedEvent.md
@@ -23,12 +23,12 @@ and delivery pipeline and the systems (e.g IT Monitoring Systems) supporting the
 ## Data Members
 ### data.heading
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The heading of the incident that occurred.
 
 ### data.body
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The body of the incident that occurred.
 
 ### data.uri
@@ -43,8 +43,8 @@ __Description:__ The identity of the user or entity that raised the incident.
 
 ### data.severity
 __Type:__ String  
-__Required:__ Yes
-__Legal values:__ MINOR, MAJOR, CRITICAL, BLOCKER, CANCELED
+__Required:__ Yes  
+__Legal values:__ MINOR, MAJOR, CRITICAL, BLOCKER, CANCELED  
 __Description:__ The severity of the incident.The CANCELED value SHOULD only be used when following up a 
 previous Alert raised event which should be linked with MODIFIED_ALERT.
  
@@ -77,25 +77,25 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -106,7 +106,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -142,19 +142,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -166,37 +166,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
@@ -23,12 +23,12 @@ The EiffelArtifactDeployedEvent is to declare that an artifact has been deployed
 ### data.uri
 __Type:__ String  
 __Required:__ No  
-__Description:__A URI where further information can be obtained, if applicable.
+__Description:__ A URI where further information can be obtained, if applicable.
 
 ## Links 
 
 ### ARTIFACT
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelArtifactCreatedEvent](https://github.com/eiffel-community/eiffel/blob/edition-agen/eiffel-vocabulary/EiffelArtifactCreatedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the artifact that was deployed
@@ -57,25 +57,25 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -86,7 +86,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -122,21 +122,21 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
+__Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct   __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
 1. Serialize the event on [Canonical JSON Form](https://tools.ietf.org/html/draft-staykov-hu-json-canonical-form-00).
 1. Generate the signature using the __meta.security.integrityProtection.alg__ algorithm.
@@ -146,37 +146,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceAllocatedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceAllocatedEvent.md
@@ -21,12 +21,12 @@ The EiffelServiceAllocatedEvent is to declare that the infrastructure needed for
 ## Data Members
 ### data.serviceinstance
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The name of the Service instance that was allocated
 
 ### data.owner
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The entity that has been assigned/responsible for the Service.
 
 ### data.uri
@@ -58,25 +58,25 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -87,7 +87,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -123,21 +123,21 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
+__Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct   __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
 1. Serialize the event on [Canonical JSON Form](https://tools.ietf.org/html/draft-staykov-hu-json-canonical-form-00).
 1. Generate the signature using the __meta.security.integrityProtection.alg__ algorithm.
@@ -147,37 +147,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceDeployedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceDeployedEvent.md
@@ -16,23 +16,23 @@
 --->
  
 # EiffelServiceDeployedEvent  (ServDe)
-TThe EiffelServiceDeployedEvent is to declare that a previously allocated service instance (declared by [EiffelServiceAllocatedEvent](./EiffelServiceAllocatedEvent.md)) has been configured and deployed with required Artifacts by a machine/human.
+The EiffelServiceDeployedEvent is to declare that a previously allocated service instance (declared by [EiffelServiceAllocatedEvent](./EiffelServiceAllocatedEvent.md)) has been configured and deployed with required Artifacts by a machine/human.
 It implies that the service instance is ready to be started.
 
 ## Data Members
 ### data.servicename
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The name of the Service that was deployed.
 
 ### data.instancename
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The name of the instance that was deployed.
 
 ### data.owner
 __Type:__ String  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The entity that has been assigned/responsible for the Service.
 
 ### data.deploymentType
@@ -59,7 +59,7 @@ __Multiple allowed:__ Yes
 __Description:__ Identifies a cause of the event occurring. SHOULD not be used in conjunction with __CONTEXT__: individual events providing __CAUSE__ within a larger context gives rise to ambiguity. It is instead recommended to let the root event of the context declare __CAUSE__.  
 
 ### CONTEXT
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelServiceAllocatedEvent](./EiffelServiceAllocatedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the service that artifacts was deployed at
@@ -82,25 +82,25 @@ __Description:__ Identifies the service that have been allocated
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -111,7 +111,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -147,19 +147,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -171,37 +171,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceDiscontinuedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceDiscontinuedEvent.md
@@ -39,7 +39,7 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 
 ### SERVICE
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelServiceDeployedEvent](./EiffelServiceDeployedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the service that have been stopped
@@ -49,25 +49,25 @@ __Description:__ Identifies the service that have been stopped
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -78,7 +78,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -114,19 +114,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -138,37 +138,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceReturnedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceReturnedEvent.md
@@ -39,7 +39,7 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 
 ### SERVICE
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelServiceDeployedEvent](./EiffelServiceDeployedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the service has been returned back to Orchestrator
@@ -49,25 +49,25 @@ __Description:__ Identifies the service has been returned back to Orchestrator
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -78,7 +78,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -114,19 +114,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -138,37 +138,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceStartedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceStartedEvent.md
@@ -45,7 +45,7 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 
 ### SERVICE
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelServiceDeployedEvent](./EiffelServiceDeployedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the service that have been started
@@ -55,25 +55,25 @@ __Description:__ Identifies the service that have been started
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -84,7 +84,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -120,19 +120,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -144,37 +144,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 

--- a/eiffel-vocabulary/EiffelServiceStoppedEvent.md
+++ b/eiffel-vocabulary/EiffelServiceStoppedEvent.md
@@ -39,7 +39,7 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 
 ### SERVICE
-__Required:__ Yes
+__Required:__ Yes  
 __Legal targets:__ [EiffelServiceDeployedEvent](./EiffelServiceDeployedEvent.md)  
 __Multiple allowed:__ No  
 __Description:__ Identifies the service that have been stopped
@@ -49,25 +49,25 @@ __Description:__ Identifies the service that have been stopped
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The unique identity of the event, generated at event creation.
 
 ### meta.type
 __Type:__ String  
 __Format:__ An event type name  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The type of event. This field is required by the recipient of the event, as each event type has a specific meaning and a specific set of members in the __data__ and __links__ objects.
 
 ### meta.version
 __Type:__ String  
 __Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
-__Required:__ Yes
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](../eiffel-syntax-and-usage/versioning.md) for more information.
+__Required:__ Yes  
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/versioning.md) for more information.
 
 ### meta.time
-__Type:__ Integer
+__Type:__ Integer  
 __Format:__ Milliseconds since epoch.  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The event creation timestamp.
 
 ### meta.tags
@@ -78,7 +78,7 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 
 ### meta.source
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
@@ -114,19 +114,19 @@ __Description:__ The URI of, related to or describing the event sender.
 
 ### meta.security
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
-__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](../eiffel-syntax-and-usage/security.md) for further information.
+__Description:__ An optional object for enclosing security related information, particularly supporting data integrity. See [Security](https://github.com/eiffel-community/eiffel/blob/master/eiffel-syntax-and-usage/security.md) for further information.
 
 #### meta.security.authorIdentity
 __Type:__ String  
 __Format:__ [Distinguished Name](https://tools.ietf.org/html/rfc2253)  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The identity of the author of the event. This property is intended to enable the recipient to identify the author of the event contents and/or look up the appropriate public key for decrypting the __meta.security.integrityProtection.signature__ value and thereby verifying author identity and data integrity.
 
 #### meta.security.integrityProtection
 __Type:__ Object  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling information integrity protection via cryptographic signing. To generate a correct __meta.security.integrityProtection__ object:
 1. Generate the entire event, but with the __meta.security.integrityProtection.signature__ value set to an empty string.
@@ -138,37 +138,37 @@ To verify the integrity of the event, the consumer then resets __meta.security.i
 ##### meta.security.integrityProtection.alg
 __Type:__ String  
 __Format:__ [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1), excluding "none"  
-__Required:__ Yes
+__Required:__ Yes  
 __Description:__ The cryptographic algorithm used to digitally sign the event. If no signing is performed, the __meta.security.integrityProtection__ SHALL be omitted rather than setting __meta.security.integrityProtection.alg__ to "none".
 
 ##### meta.security.integrityProtection.signature
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The signature produced by the signing algorithm.
 
 ##### meta.security.integrityProtection.publicKey
 __Type:__ String  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ The producer of the event may include the relevant public key for convenience, rather than relying a separate key distribution mechanism. Note that this property, along with the rest of the event, is encompassed by the integrity protection offered via __meta.security.integrityProtection__.
 
 #### meta.security.sequenceProtection
 __Type:__ Object[]  
-__Format:__
+__Format:__  
 __Required:__ No  
 __Description:__ An optional object for enabling verification of intact event sequences in a distributed environment, thereby protecting against data loss, race conditions and replay attacks. It allows event publishers to state the order in which they produce a certain set of events. In other words, it cannot provide any global guarantees as to event sequencing, but rather per-publisher guarantees. Every object in the array represents a named sequence of which this event forms a part. For every event including a given named sequence, the publisher SHALL increment __meta.security.sequenceProtection.position__ by 1. The first event produced in a given named sequence SHALL numbered 1.
 
 ##### meta.security.sequenceProtection.sequenceName
 __Type:__ String  
-__Format:__
-__Required:__ Yes
+__Format:__  
+__Required:__ Yes  
 __Description:__ The name of the sequence. There MUST not be two identical __meta.security.sequenceProtection.sequenceName__ values in the same event.
 
 ##### meta.security.sequenceProtection.position
-__Type:__ Integer
-__Format:__
-__Required:__ Yes
+__Type:__ Integer  
+__Format:__  
+__Required:__ Yes  
 __Description:__ The number of the event within the named sequence.
 
 


### PR DESCRIPTION
**Description:**
All versioning links are pointing to the core protocol repository.
Adjusted the markdown to be more readable.